### PR TITLE
Update LikeCommentServiceProvider.php

### DIFF
--- a/src/LikeCommentServiceProvider.php
+++ b/src/LikeCommentServiceProvider.php
@@ -30,8 +30,8 @@ class LikeCommentServiceProvider extends ServiceProvider
     {
         // Route
         include __DIR__.'/routes.php';
-
-        $this->app['LaravelLikeComment'] = $this->app->share(function($app) {
+        
+        $this->app->singleton('LaravelLikeComment', function ($app){
             return new LaravelLikeComment;
         });
 


### PR DESCRIPTION
Call to undefined method Illuminate\Foundation\Application::bindShared() after updating to Laravel 5.4
updated to use singleton instead of share()